### PR TITLE
Include libstormarray.h in native.c

### DIFF
--- a/native.c
+++ b/native.c
@@ -15,6 +15,7 @@
 #include <interface.h>
 #include <stdlib.h>
 #include <libstorm.h>
+#include <libstormarray.h>
 
 /**
  * This is required for the LTR patch that puts module tables


### PR DESCRIPTION
As Leonard, Michael, and I were working on implementing SVCD.notify in C, we realized that we needed to include libstorm.h in native.c. Since others will most likely run into the same issue, we decided to make a pull request for the change.
