### PR TITLE
Object oriented ADC interface for firestorm

### DIFF
--- a/natlib/analog/analog.h
+++ b/natlib/analog/analog.h
@@ -18,8 +18,21 @@
 #ifndef __ANALOG_H__
 #define __ANALOG_H__
 
-void c_adcife_init();
-int c_adcife_sample_channel(uint8_t channel);
+#define ANALOG_REFGND_N 21
 
+typedef struct
+{
+    uint8_t poschan;
+    uint8_t negchan;
+    uint8_t gain;
+    uint8_t resolution;
+} __attribute__((packed)) storm_adc_t;
+
+int adcife_sample(lua_State *L);
+int adcife_init(lua_State *L);
+int adcife_new(lua_State *L);
+
+void c_adcife_init();
+int c_adcife_sample_channel(uint8_t poschan, uint8_t negchan, uint8_t gain, uint8_t resolution);
 
 #endif

--- a/natlib/analog/analog.h
+++ b/natlib/analog/analog.h
@@ -32,7 +32,4 @@ int adcife_sample(lua_State *L);
 int adcife_init(lua_State *L);
 int adcife_new(lua_State *L);
 
-void c_adcife_init();
-int c_adcife_sample_channel(uint8_t poschan, uint8_t negchan, uint8_t gain, uint8_t resolution);
-
 #endif


### PR DESCRIPTION
Finished the ADC interface for firestorm. 

Example usage:

storm.n.adcife_init()
a0 = storm.n.adcife_new(storm.io.A0, storm.io.LOW, storm.n.adcife_ADC_REFGND, storm.n.adcife_12BIT)
v = a0:sample()
print(v)

The value "v" returned is the raw value as documented in 38.6.12 (p1000) in the datasheet. The user is responsible to take the conversion from this value to engineering values by solving the equation such as:

2047 + (Vin/Vref)*2047 = v 
--> Vin = (v - 2047) / 2047 \* Vref

However as eLua shell does not support floating points, I suggest multiply by 1000 before any division to get a mV engineering unit or other meaningful units. 

[BEARCAST]
